### PR TITLE
Bump regexp to allow for hardened dmesg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,11 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant.git', tag: 'v1.8.4'
+  gem 'vagrant', :git => 'https://github.com/mitchellh/vagrant.git', tag: 'v1.9.5'
 end
 
 group :plugins do
-  gem 'vagrant-bhyve', path: '.'
+  #gem 'vagrant-bhyve', path: '.'
   #gem 'vagrant-sshfs', '1.1.0'
   #gem 'vagrant-mutate', :git => 'https://github.com/swills/vagrant-mutate'
 end

--- a/lib/vagrant-bhyve/driver.rb
+++ b/lib/vagrant-bhyve/driver.rb
@@ -126,11 +126,11 @@ module VagrantPlugins
 	raise Errors::SystemVersionIsTooLow if result == 0
 
 	# Check whether POPCNT is supported
-	result = execute(false, "#{@sudo} grep -E '^[ ] +Features2' /var/run/dmesg.boot | tail -n 1")
+	result = execute(false, "#{@sudo} grep -E '[^\[\d*\]]?[ ]* +Features2' /var/run/dmesg.boot | grep -v AMD")
 	raise Errors::MissingPopcnt unless result =~ /POPCNT/
 
 	# Check whether EPT is supported for Intel
-	result = execute(false, "#{@sudo} grep -E '^[ ]+VT-x' /var/run/dmesg.boot | tail -n 1")
+	result = execute(false, "#{@sudo} grep -E '[^\[\d*\]]?[ ]*VT-x:' /var/run/dmesg.boot | tail -n 1")
 	raise Errors::MissingEpt unless result =~ /EPT/
 
 	# Check VT-d 

--- a/lib/vagrant-bhyve/version.rb
+++ b/lib/vagrant-bhyve/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module ProviderBhyve
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
Currently, the grepping of dmesg can't work with timestamps at the beginning of dmesg (via setting `kern.msgbuf_show_timestamp=1`).

Patch attached fixes the regexp to match both timestamped and untimestamped dmesg output.

Likewise it fixes the issue where Popcnt couldn't be found because your processor issues two Features2 lines, like in the following:

```
[1]   Features2=0x7ffafbbf<SSE3,PCLMULQDQ,DTES64,MON,DS_CPL,VMX,EST,TM2,SSSE3,SDBG,FMA,CX16,xTPR,PDCM,PCID,SSE4.1,SSE4.2,x2APIC,MOVBE,POPCNT,TSCDLT,AESNI,XSAVE,OSXSAVE,AVX,F16C,RDRAND>
[1]   AMD Features2=0x121<LAHF,ABM,Prefetch>
```